### PR TITLE
update manual installation instructions

### DIFF
--- a/src/content/docs/get-started/manual-install/linux-guide.mdx
+++ b/src/content/docs/get-started/manual-install/linux-guide.mdx
@@ -41,34 +41,17 @@ For example, assuming `$STEAMLIBRARY` points to your Steam library, IW4x can be 
    curl -L https://github.com/iw4x/iw4x-client/releases/latest/download/iw4x.dll -o iw4x.dll
    ```
 
-2. **Download `iw4x.exe`**
-
-   ```bash
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x.exe -o iw4x.exe
-   ```
-
-3. **Download `raw files`**
+2. **Download `raw files` and `iw4x.exe`**
 
    ```bash
    curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/release.zip -o release.zip
    ```
 
-4. **Extract archive**
+3. **Extract archive**
 
     ```bash
     unzip -o release.zip -d "$STEAMLIBRARY/steamapps/common/Call of Duty Modern Warfare 2"
     ```
-
-5. **Download `iwd files`**
-
-   ```bash
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_00.iwd -o iw4x/iw4x_00.iwd
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_01.iwd -o iw4x/iw4x_01.iwd
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_02.iwd -o iw4x/iw4x_02.iwd
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_03.iwd -o iw4x/iw4x_03.iwd
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_04.iwd -o iw4x/iw4x_04.iwd
-   curl -L https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_05.iwd -o iw4x/iw4x_05.iwd
-   ```
 
 </Steps>
 
@@ -129,7 +112,7 @@ Though more involved, this method grants precise control over the runtime enviro
 
 ## Install using POSIX Shell Script
 
-Once of our awesome community members maintains script that automates  installing and updating IW4x on Linux!  
+One of our awesome community members maintains script that automates installing and updating IW4x on Linux and other unix-likes!
 You can check it out here: https://github.com/kkrruumm/iw4x-updoot  
 Make sure to read through their README for usage instructions and details.
 

--- a/src/content/docs/get-started/manual-install/macos-guide.mdx
+++ b/src/content/docs/get-started/manual-install/macos-guide.mdx
@@ -173,13 +173,6 @@ iconPlacement="start"
 >Download **iw4x.dll**</LinkButton>
 
 <LinkButton
-href="https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x.exe"
-variant="secondary"
-icon="seti:windows"
-iconPlacement="start"
->Download **iw4x.exe**</LinkButton>
-
-<LinkButton
 href="https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/release.zip"
 variant="secondary"
 icon="seti:windows"
@@ -196,7 +189,7 @@ iconPlacement="start"
 2. Extract `release.zip` into this folder.
 	* Ensure the files (`iw4x` folder, `zone` folder) are in the root of the game folder, not a sub-folder.
 
-3. Place `iw4x.dll` and `iw4x.exe` into this folder.
+3. Place `iw4x.dll` into this folder.
 
 4. Delete `installscript.vdf` if it exists.
 </Steps>

--- a/src/content/docs/get-started/manual-install/windows-guide.mdx
+++ b/src/content/docs/get-started/manual-install/windows-guide.mdx
@@ -55,17 +55,10 @@ Once you've located the Modern Warfare 2 game directory, you can download the la
 
 <Video src={download_iw4x} />
 
-## 3. Download Raw Files
+## 3. Download Raw Files and `iw4x.exe`
 
 The [raw files](https://github.com/iw4x/iw4x-rawfiles) are additional assets like maps, weapons, and scripts that enhance your IW4x experience.  
 Like in the [previous step](#2-download-iw4x), download and save the latest release version into your game directory.
-
-<LinkButton
-    href="https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x.exe"
-    variant="primary"
-    icon="seti:windows"
-    iconPlacement="start"
->Download **iw4x.exe**</LinkButton>
 
 <LinkButton
     href="https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/release.zip"
@@ -74,9 +67,9 @@ Like in the [previous step](#2-download-iw4x), download and save the latest rele
     iconPlacement="start"
 >Download **release.zip**</LinkButton>
 
-You'll find several more downloads on GitHub, but the most important ones are:
+You'll find several items on GitHub, but the most important ones are:
 
-- **iw4x.exe** - A custom version of the original `iw4mp.exe`, designed to load `iw4x.dll` (downloaded in the previous step)
+- **iw4x.exe** - A custom version of the original `iw4mp.exe`, designed to load `iw4x.dll` (included in `release.zip`)
 - **release.zip** - Contains all required extra assets for IW4x
 
 Additional files you may encounter:
@@ -130,40 +123,22 @@ The instructions below simply show how to perform the same steps using PowerShel
    Start-BitsTransfer -source https://github.com/iw4x/iw4x-client/releases/latest/download/iw4x.dll
    ```
 
-3. **Download `iw4x.exe`**
-
-   ```ps
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x.exe
-   ```
-
-4. **Download `release.zip`**
+3. **Download `release.zip`**
 
    ```ps
    Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/release.zip
    ```
 
-5. **Extract `release.zip`**
+4. **Extract `release.zip`**
 
    ```ps
    Expand-Archive release.zip -DestinationPath .
    ```
 
-6. **Delete `release.zip`**
+5. **Delete `release.zip`**
 
    ```ps
    Remove-Item release.zip
-   ```
-
-7. **Download `.iwd files`**
-
-   ```ps
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_00.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_00.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_01.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_02.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_03.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_04.iwd iw4x
-   Start-BitsTransfer -source https://github.com/iw4x/iw4x-rawfiles/releases/latest/download/iw4x_05.iwd iw4x
    ```
 
 </Steps>


### PR DESCRIPTION
`release.zip` now includes all of the .iwd archives as well as `iw4x.exe`

at the moment, the download links described in the doc are invalid as the filenames have also changed